### PR TITLE
Rename PAUSED to STOPPED, and added real PAUSED

### DIFF
--- a/rockin/clips/benchmark.clp
+++ b/rockin/clips/benchmark.clp
@@ -70,8 +70,13 @@
   (benchmark-reset)
 )
 
+(defrule benchmark-swtich-to-pause
+  ?bs <- (benchmark-state (state PAUSED) (prev-state RUNNING))
+  =>
+  (modify ?bs (prev-state PAUSED))
+)
 
-; Initialize and directly transition to PAUSED state
+; Initialize and directly transition to STOPPED state
 (defrule benchmark-fbm-init
   (benchmark-phase (id ?phase) (type FBM) (type-id ?fbm-id))
   ?bs <- (benchmark-state (phase-id ?phase) (state INIT))
@@ -80,38 +85,38 @@
 
   (switch ?fbm-id
     (case 1 then
-      (modify ?bs (state PAUSED) (prev-state INIT) (max-runs ?*FBM1-COUNT*)
+      (modify ?bs (state STOPPED) (prev-state INIT) (max-runs ?*FBM1-COUNT*)
           (max-time ?*FBM1-TIME*) (run 1) (benchmark-time 0.0))
     )
     (case 2 then
-      (modify ?bs (state PAUSED) (prev-state INIT) (max-runs ?*FBM2-COUNT*)
+      (modify ?bs (state STOPPED) (prev-state INIT) (max-runs ?*FBM2-COUNT*)
           (max-time ?*FBM2-TIME*) (run 1) (benchmark-time 0.0))
     )
   )
 )
 
-; Select an object when entering PAUSED state
-(defrule benchmark-fbm1-switch-to-pause
+; Select an object when entering STOPPED state
+(defrule benchmark-fbm1-switch-to-stop
   (benchmark-phase (id ?phase) (type FBM) (type-id 1))
-  ?bs <- (benchmark-state (phase-id ?phase) (state PAUSED) (prev-state ~PAUSED))
+  ?bs <- (benchmark-state (phase-id ?phase) (state STOPPED) (prev-state ~STOPPED))
   =>
-  (modify ?bs (prev-state PAUSED))
+  (modify ?bs (prev-state STOPPED))
 
   (select-random-object)
 )
 
 ; In FBM2 the RefBox does not select the object
-(defrule benchmark-fbm2-switch-to-pause
+(defrule benchmark-fbm2-switch-to-stop
   (benchmark-phase (id ?phase) (type FBM) (type-id 2))
-  ?bs <- (benchmark-state (phase-id ?phase) (state PAUSED) (prev-state ~PAUSED))
+  ?bs <- (benchmark-state (phase-id ?phase) (state STOPPED) (prev-state ~STOPPED))
   =>
-  (modify ?bs (prev-state PAUSED))
+  (modify ?bs (prev-state STOPPED))
 )
 
-; When a command switches the state from PAUSED to RUNNING, setup the current run
+; When a command switches the state from STOPPED to RUNNING, setup the current run
 (defrule benchmark-fbm-run-start
   (benchmark-phase (id ?phase) (type FBM))
-  ?bs <- (benchmark-state (phase-id ?phase) (state RUNNING) (prev-state PAUSED))
+  ?bs <- (benchmark-state (phase-id ?phase) (state RUNNING) (prev-state STOPPED))
   ?so <- (selected-object)
   =>
   (retract ?so)
@@ -138,7 +143,7 @@
            (max-runs ?max-runs) (run ?run&:(< ?run ?max-runs)))
   =>
   (retract ?ro)   ; Reset for the next run
-  (modify ?bs (state PAUSED) (prev-state RUNNING) (end-time (now)) (run (+ ?run 1)) (benchmark-time 0.0))
+  (modify ?bs (state STOPPED) (prev-state RUNNING) (end-time (now)) (run (+ ?run 1)) (benchmark-time 0.0))
 
   (printout t "FBM: Run " ?run " over" crlf)
   (assert (attention-message (text (str-cat "FBM: Run " ?run " over")) (time 15)))
@@ -306,7 +311,7 @@
 
 
 
-; Initialize and directly transition to PAUSED state
+; Initialize and directly transition to STOPPED state
 (defrule benchmark-tbm-init
   (benchmark-phase (id ?phase) (type TBM) (type-id ?fbm-id))
   ?bs <- (benchmark-state (phase-id ?phase) (state INIT))
@@ -325,14 +330,14 @@
     )
   )
 
-  (modify ?bs (state PAUSED) (prev-state INIT) (max-runs ?*TBM-COUNT*)
+  (modify ?bs (state STOPPED) (prev-state INIT) (max-runs ?*TBM-COUNT*)
       (max-time ?*TBM-TIME*) (run 1) (benchmark-time 0.0))
 )
 
-; When a command switches the state from PAUSED to RUNNING, setup the current run
+; When a command switches the state from STOPPED to RUNNING, setup the current run
 (defrule benchmark-tbm-run-start
   (benchmark-phase (id ?phase) (type TBM))
-  ?bs <- (benchmark-state (phase-id ?phase) (state RUNNING) (prev-state PAUSED))
+  ?bs <- (benchmark-state (phase-id ?phase) (state RUNNING) (prev-state STOPPED))
   =>
   (modify ?bs (prev-state RUNNING) (start-time (now)) (benchmark-time 0.0))
 

--- a/rockin/clips/facts.clp
+++ b/rockin/clips/facts.clp
@@ -62,8 +62,8 @@
 
 (deftemplate benchmark-state
   (slot refbox-mode (type SYMBOL) (allowed-values STANDALONE) (default STANDALONE))
-  (slot state (type SYMBOL) (allowed-values INIT RUNNING PAUSED FINISHED) (default INIT))
-  (slot prev-state (type SYMBOL) (allowed-values INIT RUNNING PAUSED FINISHED) (default INIT))
+  (slot state (type SYMBOL) (allowed-values INIT RUNNING PAUSED STOPPED FINISHED) (default INIT))
+  (slot prev-state (type SYMBOL) (allowed-values INIT RUNNING PAUSED STOPPED FINISHED) (default INIT))
   (slot phase-id (type INTEGER) (default 0))        ; identifier of a phase
   (slot prev-phase-id (type INTEGER) (default 0))   ; identifier of a phase
   (slot benchmark-time (type FLOAT) (default 0.0))

--- a/rockin/clips/mongodb.clp
+++ b/rockin/clips/mongodb.clp
@@ -38,7 +38,7 @@
 (defrule mongodb-fbm-start
   (declare (salience ?*PRIORITY_HIGH*))
   (benchmark-phase (id ?phase) (type FBM))
-  (benchmark-state (phase-id ?phase) (state RUNNING) (prev-state PAUSED) (run ?run))
+  (benchmark-state (phase-id ?phase) (state RUNNING) (prev-state STOPPED) (run ?run))
   (selected-object (object-id ?id))
   =>
   (bind ?bf (bson-create))
@@ -150,7 +150,7 @@
 (defrule mongodb-fbm2-feedback-client
   (declare (salience ?*PRIORITY_HIGH*))
   (benchmark-phase (id ?phase) (type FBM) (type-id 2))
-  (benchmark-state (phase-id ?phase) (state PAUSED|FINISHED) (run ?run))
+  (benchmark-state (phase-id ?phase) (state STOPPED|FINISHED) (run ?run))
   ?bf <- (benchmark-feedback (source CLIENT) (time $?time) (type ?type))
   =>
   (retract ?bf)

--- a/rockin/clips/net.clp
+++ b/rockin/clips/net.clp
@@ -767,7 +767,7 @@
   ?mf <- (protobuf-msg (type "rockin_msgs.BenchmarkFeedback") (ptr ?p)
           (rcvd-at $?rcvd-at) (rcvd-from ?from-host ?from-port) (client-type CLIENT|SERVER))
   (benchmark-phase (id ?phase) (type FBM) (type-id 2))
-  (benchmark-state (phase-id ?phase) (state PAUSED|FINISHED))
+  (benchmark-state (phase-id ?phase) (state STOPPED|FINISHED))
   =>
   (retract ?mf) ; message will be destroyed after rule completes
 

--- a/rockin/controller/rockin-controller.cpp
+++ b/rockin/controller/rockin-controller.cpp
@@ -54,23 +54,32 @@ bool idle_handler() {
 
   if (benchmark_state) {
     Gtk::Button *button_start = 0;
+    Gtk::Button *button_pause = 0;
     Gtk::Button *button_success = 0;
     Gtk::Button *button_fail = 0;
     builder->get_widget("button_start", button_start);
+    builder->get_widget("button_pause", button_pause);
     builder->get_widget("button_success", button_success);
     builder->get_widget("button_fail", button_fail);
 
-    // Only activate in PAUSED state
-    if (benchmark_state->state() == rockin_msgs::BenchmarkState::PAUSED) {
+    // Only activate in STOPPED or PAUSED state
+    if ((benchmark_state->state() == rockin_msgs::BenchmarkState::STOPPED)
+        || (benchmark_state->state() == rockin_msgs::BenchmarkState::PAUSED)) {
       button_start->set_sensitive(true);
     } else {
       button_start->set_sensitive(false);
     }
+    // Only activate in RUNNING state
+    if (benchmark_state->state() == rockin_msgs::BenchmarkState::RUNNING) {
+      button_pause->set_sensitive(true);
+    } else {
+      button_pause->set_sensitive(false);
+    }
 
-    // Only activate in FBM2 during PAUSED or FINISHED state
+    // Only activate in FBM2 during STOPPED or FINISHED state
     if ((benchmark_state->phase().type() == rockin_msgs::BenchmarkPhase::FBM)
         && (benchmark_state->phase().type_id() == 2)
-        && ((benchmark_state->state() == rockin_msgs::BenchmarkState::PAUSED)
+        && ((benchmark_state->state() == rockin_msgs::BenchmarkState::STOPPED)
          || benchmark_state->state() == rockin_msgs::BenchmarkState::FINISHED)) {
       button_success->set_sensitive(true);
       button_fail->set_sensitive(true);
@@ -98,6 +107,12 @@ void on_start_click()
   client.send(cmd_state);
 }
 
+void on_pause_click()
+{
+  rockin_msgs::SetBenchmarkState cmd_state;
+  cmd_state.set_state(rockin_msgs::BenchmarkState::PAUSED);
+  client.send(cmd_state);
+}
 
 void on_reset_click()
 {
@@ -157,7 +172,6 @@ void on_cb_start_click()
   client.send(msg);
 }
 
-
 void on_cb_stop_click()
 {
   rockin_msgs::ConveyorBeltCommand msg;
@@ -200,6 +214,7 @@ int main(int argc, char **argv)
   window->show_all();
 
   Gtk::Button *button_start = 0;
+  Gtk::Button *button_pause = 0;
   Gtk::Button *button_success = 0;
   Gtk::Button *button_fail = 0;
   Gtk::Button *button_reset = 0;
@@ -208,6 +223,7 @@ int main(int argc, char **argv)
   Gtk::Button *button_dm_up = 0;
   Gtk::Button *button_dm_down = 0;
   builder->get_widget("button_start", button_start);
+  builder->get_widget("button_pause", button_pause); 
   builder->get_widget("button_success", button_success);
   builder->get_widget("button_fail", button_fail);
   builder->get_widget("button_reset", button_reset);
@@ -218,6 +234,7 @@ int main(int argc, char **argv)
 
   Glib::signal_idle().connect(sigc::ptr_fun(&idle_handler));
   button_start->signal_clicked().connect(sigc::ptr_fun(&on_start_click));
+  button_pause->signal_clicked().connect(sigc::ptr_fun(&on_pause_click));
   button_success->signal_clicked().connect(sigc::ptr_fun(&on_success_click));
   button_fail->signal_clicked().connect(sigc::ptr_fun(&on_fail_click));
   button_reset->signal_clicked().connect(sigc::ptr_fun(&on_reset_click));

--- a/rockin/controller/rockin_controller.glade
+++ b/rockin/controller/rockin_controller.glade
@@ -11,7 +11,7 @@
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkFrame" id="frame1">
+          <object class="GtkFrame" id="benchmark-control">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label_xalign">0</property>
@@ -25,12 +25,39 @@
                 <property name="left_padding">12</property>
                 <property name="right_padding">12</property>
                 <child>
-                  <object class="GtkButton" id="button_start">
-                    <property name="label" translatable="yes">Start</property>
+                  <object class="GtkBox" id="box6">
                     <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkButton" id="button_start">
+                        <property name="label" translatable="yes">Start</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_pause">
+                        <property name="label" translatable="yes">Pause</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="yalign">0.44999998807907104</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/rockin/msgs/BenchmarkState.proto
+++ b/rockin/msgs/BenchmarkState.proto
@@ -58,7 +58,8 @@ message BenchmarkState {
     INIT      = 0;
     RUNNING   = 1;
     PAUSED    = 2;
-    FINISHED  = 3;
+    STOPPED   = 3;
+    FINISHED  = 4;
   }
 
   enum RefBoxMode {

--- a/rockin/tools/rockin-benchmark-ctrl.cpp
+++ b/rockin/tools/rockin-benchmark-ctrl.cpp
@@ -50,6 +50,7 @@ void handle_message(uint16_t comp_id, uint16_t msg_type,
       case rockin_msgs::BenchmarkState::INIT: std::cout << "INIT"; break;
       case rockin_msgs::BenchmarkState::RUNNING: std::cout << "RUNNING"; break;
       case rockin_msgs::BenchmarkState::PAUSED: std::cout << "PAUSED"; break;
+      case rockin_msgs::BenchmarkState::STOPPED: std::cout << "STOPPED"; break;
       case rockin_msgs::BenchmarkState::FINISHED: std::cout << "FINISHED"; break;
     }
     std::cout << std::endl;

--- a/rockin/tools/rockin-fake-robot.cpp
+++ b/rockin/tools/rockin-fake-robot.cpp
@@ -129,6 +129,7 @@ handle_message(boost::asio::ip::udp::endpoint &sender,
       case BenchmarkState::INIT: std::cout << "INIT" << std::endl; break;
       case BenchmarkState::RUNNING: std::cout << "RUNNING" << std::endl; break;
       case BenchmarkState::PAUSED: std::cout << "PAUSED" << std::endl; break;
+      case BenchmarkState::STOPPED: std::cout << "PAUSED" << std::endl; break;
       case BenchmarkState::FINISHED: std::cout << "FINISHED" << std::endl; break;
     }
 

--- a/rockin/tools/rockin-fake-robot.cpp
+++ b/rockin/tools/rockin-fake-robot.cpp
@@ -129,7 +129,7 @@ handle_message(boost::asio::ip::udp::endpoint &sender,
       case BenchmarkState::INIT: std::cout << "INIT" << std::endl; break;
       case BenchmarkState::RUNNING: std::cout << "RUNNING" << std::endl; break;
       case BenchmarkState::PAUSED: std::cout << "PAUSED" << std::endl; break;
-      case BenchmarkState::STOPPED: std::cout << "PAUSED" << std::endl; break;
+      case BenchmarkState::STOPPED: std::cout << "STOPPED" << std::endl; break;
       case BenchmarkState::FINISHED: std::cout << "FINISHED" << std::endl; break;
     }
 

--- a/rockin/viewer/rockin-viewer.cpp
+++ b/rockin/viewer/rockin-viewer.cpp
@@ -179,6 +179,11 @@ bool idle_handler() {
         label_state->set_text("Paused");
       break;
 
+      case rockin_msgs::BenchmarkState::STOPPED:
+        fg_color = Pango::Attribute::create_attr_foreground(61423, 10537, 10537);
+        label_state->set_text("Stopped");
+      break;
+
       case rockin_msgs::BenchmarkState::FINISHED:
         fg_color = Pango::Attribute::create_attr_foreground(61423, 10537, 10537);
         label_state->set_text("Finished");


### PR DESCRIPTION
Previously, the benchmark state "PAUSED" was actually stopped.
ie: the time was reset, there was no way to continue or unpause,
 once the state was paused, it was really stopped, there was no
 transition back to running.

The old state PAUSED has been renamed STOPPED, all previous checks for
 PAUSED have been switched to STOPPED. When the refbox exists INIT
 state, it transitions to STOPPED state and waits to be started.
 previously it entered PAUSED after INIT, before RUNNING.

The PAUSED benchmark state now pauses the benchmark, which essentially
 only stops the timer, everything else remains unchanged, allowing for
 the benchmark to be unpaused and transition back to RUNNING.

In the benchmark-controller GUI, a Pause button is now located under the
 Start button. This button is only enabled in RUNNING. The Start button
 is now enabled during STOPPED or PAUSED.
