### PR TITLE
Adds simulation and mockup threads for drilling machine plugin

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -18,7 +18,7 @@ llsfrb:
     status_port: !tcp-port 55501
 
   drilling-machine:
-    enable: false
+    mode: simulation
     host: !ipv4 eth0
     command_port: !tcp-port 55512
     status_port: !tcp-port 55511

--- a/rockin/plugins/drilling_machine/Makefile
+++ b/rockin/plugins/drilling_machine/Makefile
@@ -23,7 +23,9 @@ REQ_BOOST_LIBS = thread system
 HAVE_BOOST_LIBS = $(call boost-have-libs,$(REQ_BOOST_LIBS))
 
 LIBS_drilling_machine = llsfrbcore llsfrbaspects rockin_plugin_msgs
-OBJS_drilling_machine = drilling_machine_plugin.o drilling_machine_thread.o
+OBJS_drilling_machine = drilling_machine_plugin.o drilling_machine_thread.o \
+                        drilling_machine_simulation_thread.o \
+                        drilling_machine_mockup_thread.o
 
 ifeq ($(HAVE_CLIPS)$(HAVE_PROTOBUF)$(HAVE_LIBZMQ)$(HAVE_BOOST_LIBS),1111)
   OBJS_all    = $(OBJS_drilling_machine)

--- a/rockin/plugins/drilling_machine/drilling_machine_mockup_thread.cpp
+++ b/rockin/plugins/drilling_machine/drilling_machine_mockup_thread.cpp
@@ -1,0 +1,87 @@
+/***************************************************************************
+ *  drilling_machine_mockup_thread.cpp - Thread to mockup the drilling machine
+ *
+ *  Created: Mon Oct 5 12:25:11 2015
+ *  Copyright  2015 Alexander Moriarty
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "drilling_machine_mockup_thread.h"
+
+#include <core/threading/mutex_locker.h>
+#include <boost/lexical_cast.hpp>
+#include <boost/thread/thread.hpp>
+
+/** @class DrillingMachineMockupThread
+ * Thread to mockup RoCKIn@Work drilling machine.
+ * @author Alexander Moriarty
+ */
+
+/** Constructor. */
+DrillingMachineMockupThread::DrillingMachineMockupThread() :
+    Thread("DrillingMachineMockupThread", Thread::OPMODE_CONTINUOUS),
+    cfg_timer_interval_(40)
+{
+}
+
+void DrillingMachineMockupThread::init()
+{
+    try
+    {
+        cfg_timer_interval_ = config->get_uint("/llsfrb/clips/timer-interval");
+    } catch (fawkes::Exception &e)
+    {
+        // use default value
+    }
+
+    logger->log_info("DrillingMachine", "Plugin is in mockup mode.");
+
+    fawkes::MutexLocker lock(clips_mutex);
+
+    clips->add_function("drilling-machine-move-drill-up", sigc::slot<void>(sigc::mem_fun(*this, &DrillingMachineMockupThread::clips_move_drill_up)));
+    clips->add_function("drilling-machine-move-drill-down", sigc::slot<void>(sigc::mem_fun(*this, &DrillingMachineMockupThread::clips_move_drill_down)));
+    clips->add_function("drilling-machine-get-state", sigc::slot<int>(sigc::mem_fun(*this, &DrillingMachineMockupThread::clips_get_device_state)));
+    clips->add_function("drilling-machine-is-device-connected", sigc::slot<int>(sigc::mem_fun(*this, &DrillingMachineMockupThread::clips_is_device_connected)));
+
+    if (!clips->build("(deffacts have-feature-drilling-machine (have-feature DrillingMachine))"))
+        logger->log_warn("DrillingMachine", "Failed to build deffacts have-feature-drilling-machine");
+}
+
+void DrillingMachineMockupThread::finalize()
+{
+}
+
+void DrillingMachineMockupThread::loop()
+{
+    boost::this_thread::sleep(boost::posix_time::milliseconds(cfg_timer_interval_));
+}
+
+DrillingMachineStatus::State DrillingMachineMockupThread::clips_get_device_state()
+{
+    return DrillingMachineStatus::UNKNOWN;
+}
+
+int DrillingMachineMockupThread::clips_is_device_connected()
+{
+    return false;
+}
+
+void DrillingMachineMockupThread::clips_move_drill_up()
+{
+}
+
+void DrillingMachineMockupThread::clips_move_drill_down()
+{
+}

--- a/rockin/plugins/drilling_machine/drilling_machine_mockup_thread.h
+++ b/rockin/plugins/drilling_machine/drilling_machine_mockup_thread.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+ *  drilling_machine_mockup_thread.h - Thread to mockup the drilling machine
+ *
+ *  Created: Mon Oct 5 12:20:11 2015
+ *  Copyright  2015 Alexander Moriarty
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef __PLUGINS_DRILLING_MACHINE_MOCKUP_THREAD_H_
+#define __PLUGINS_DRILLING_MACHINE_MOCKUP_THREAD_H_
+
+#include <core/threading/thread.h>
+#include <aspect/logging.h>
+#include <aspect/clips.h>
+#include <aspect/configurable.h>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <plugins/msgs/DeviceDrillingMachine.pb.h>
+
+class DrillingMachineMockupThread: public fawkes::Thread, public fawkes::LoggingAspect, public fawkes::ConfigurableAspect, public fawkes::CLIPSAspect
+{
+    public:
+        DrillingMachineMockupThread();
+
+        virtual void init();
+        virtual void loop();
+        virtual void finalize();
+
+    private:
+        void clips_move_drill_up();
+        void clips_move_drill_down();
+        DrillingMachineStatus::State clips_get_device_state();
+        int clips_is_device_connected();
+
+    private:
+        unsigned int cfg_timer_interval_;
+};
+
+#endif

--- a/rockin/plugins/drilling_machine/drilling_machine_plugin.cpp
+++ b/rockin/plugins/drilling_machine/drilling_machine_plugin.cpp
@@ -21,6 +21,8 @@
 #include <core/plugin.h>
 
 #include "drilling_machine_thread.h"
+#include "drilling_machine_simulation_thread.h"
+#include "drilling_machine_mockup_thread.h"
 
 using namespace fawkes;
 
@@ -31,14 +33,22 @@ class DrillingMachinePlugin: public fawkes::Plugin
 {
     public:
         /** Constructor.
-         * @param config Fawkes configuration
-         */
-        DrillingMachinePlugin(Configuration *config) :
-                Plugin(config)
+        * @param config Fawkes configuration
+        */
+        DrillingMachinePlugin(Configuration *config): Plugin(config)
         {
-            thread_list.push_back(new DrillingMachineThread());
+            if (config->exists("/llsfrb/drilling-machine/mode"))
+            {
+                std::string config_mode = config->get_string("/llsfrb/drilling-machine/mode");
+                if (config_mode == std::string("real"))
+                    thread_list.push_back(new DrillingMachineThread());
+                else if (config_mode == std::string("simulation"))
+                    thread_list.push_back(new DrillingMachineSimulationThread());
+                else
+                    thread_list.push_back(new DrillingMachineMockupThread());
+            }
         }
 };
 
-PLUGIN_DESCRIPTION("Plugin to communicate with the drilling machine")
+PLUGIN_DESCRIPTION("Plugin to communicate with or simulate the drilling machine")
 EXPORT_PLUGIN(DrillingMachinePlugin)

--- a/rockin/plugins/drilling_machine/drilling_machine_simulation_thread.cpp
+++ b/rockin/plugins/drilling_machine/drilling_machine_simulation_thread.cpp
@@ -1,0 +1,138 @@
+/***************************************************************************
+ *  drilling_machine_simulation_thread.cpp - Thread to simulate the drilling machine
+ *
+ *  Created: Mon Oct 5 12:25:11 2015
+ *  Copyright  2015 Alexander Moriarty
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "drilling_machine_simulation_thread.h"
+
+#include <core/threading/mutex_locker.h>
+#include <boost/lexical_cast.hpp>
+#include <boost/thread/thread.hpp>
+
+/** @class DrillingMachineSimulationThread
+ * Thread to simulate RoCKIn@Work drilling machine.
+ * @author Alexander Moriarty
+ */
+
+/** Constructor. */
+DrillingMachineSimulationThread::DrillingMachineSimulationThread() :
+    Thread("DrillingMachineSimulationThread", Thread::OPMODE_CONTINUOUS),
+    cfg_timer_interval_(40)
+{
+}
+
+void DrillingMachineSimulationThread::init()
+{
+    try
+    {
+        cfg_timer_interval_ = config->get_uint("/llsfrb/clips/timer-interval");
+    } catch (fawkes::Exception &e)
+    {
+        // use default value
+    }
+
+    last_sent_command_timestamp_ = boost::posix_time::microsec_clock::local_time();
+
+    logger->log_info("DrillingMachineSim", "Plugin is in simulation mode.");
+
+
+    last_status_msg_.set_state(DrillingMachineStatus::AT_TOP);
+    last_status_msg_.set_is_device_connected(true);
+    tick_ = ENCODER_MAX_;
+    last_command_msg_.set_command(DrillingMachineCommand::MOVE_UP);
+    logger->log_info("DrillingMachineSim", "simulation initialized to AT_TOP, tick at %d", tick_);
+
+    fawkes::MutexLocker lock(clips_mutex);
+
+    clips->add_function("drilling-machine-move-drill-up", sigc::slot<void>(sigc::mem_fun(*this, &DrillingMachineSimulationThread::clips_move_drill_up)));
+    clips->add_function("drilling-machine-move-drill-down", sigc::slot<void>(sigc::mem_fun(*this, &DrillingMachineSimulationThread::clips_move_drill_down)));
+    clips->add_function("drilling-machine-get-state", sigc::slot<int>(sigc::mem_fun(*this, &DrillingMachineSimulationThread::clips_get_device_state)));
+    clips->add_function("drilling-machine-is-device-connected", sigc::slot<int>(sigc::mem_fun(*this, &DrillingMachineSimulationThread::clips_is_device_connected)));
+
+    if (!clips->build("(deffacts have-feature-drilling-machine (have-feature DrillingMachine))"))
+        logger->log_warn("DrillingMachineSim", "Failed to build deffacts have-feature-drilling-machine");
+}
+
+void DrillingMachineSimulationThread::finalize()
+{
+}
+
+void DrillingMachineSimulationThread::loop()
+{
+    boost::this_thread::sleep(boost::posix_time::milliseconds(cfg_timer_interval_));
+    fawkes::MutexLocker lock(clips_mutex);
+    if (last_command_msg_.command() == DrillingMachineCommand::MOVE_DOWN)
+    {
+        if (tick_ > 1)
+        {
+            last_status_msg_.set_state(DrillingMachineStatus::MOVING_DOWN);
+            tick_ -= 1;
+        } else
+        {
+            last_status_msg_.set_state(DrillingMachineStatus::AT_BOTTOM);
+        }
+    } else if (last_command_msg_.command() == DrillingMachineCommand::MOVE_UP)
+    {
+        if (tick_ < ENCODER_MAX_)
+        {
+            last_status_msg_.set_state(DrillingMachineStatus::MOVING_UP);
+            tick_ += 1;
+        } else
+        {
+            last_status_msg_.set_state(DrillingMachineStatus::AT_TOP);
+        }
+    }
+}
+
+DrillingMachineStatus::State DrillingMachineSimulationThread::clips_get_device_state()
+{
+    if (last_status_msg_.has_state())
+    {
+        return last_status_msg_.state();
+    }
+    return DrillingMachineStatus::UNKNOWN;
+}
+
+int DrillingMachineSimulationThread::clips_is_device_connected()
+{
+    return (last_status_msg_.has_is_device_connected() && last_status_msg_.is_device_connected());
+}
+
+void DrillingMachineSimulationThread::clips_move_drill_up()
+{
+    moveDrill(DrillingMachineCommand::MOVE_UP);
+}
+
+void DrillingMachineSimulationThread::clips_move_drill_down()
+{
+    moveDrill(DrillingMachineCommand::MOVE_DOWN);
+}
+
+void DrillingMachineSimulationThread::moveDrill(DrillingMachineCommand::Command drill_command)
+{
+    // prevent sending to many messages to the device
+    boost::posix_time::time_duration time_diff;
+    time_diff = boost::posix_time::microsec_clock::local_time() - last_sent_command_timestamp_;
+    if (time_diff.total_milliseconds() < 200)
+        return;
+
+    last_command_msg_.set_command(drill_command);
+    last_sent_command_timestamp_ = boost::posix_time::microsec_clock::local_time();
+
+    logger->log_info("DrillingMachineSim", "Send drill command: %d", drill_command);
+}

--- a/rockin/plugins/drilling_machine/drilling_machine_simulation_thread.cpp
+++ b/rockin/plugins/drilling_machine/drilling_machine_simulation_thread.cpp
@@ -138,5 +138,5 @@ void DrillingMachineSimulationThread::moveDrill(DrillingMachineCommand::Command 
     last_command_msg_.set_command(drill_command);
     last_sent_command_timestamp_ = boost::posix_time::microsec_clock::local_time();
 
-    logger->log_info("DrillingMachineSim", "Send drill command: %d", drill_command);
+    logger->log_debug("DrillingMachineSim", "Send drill command: %d", drill_command);
 }

--- a/rockin/plugins/drilling_machine/drilling_machine_simulation_thread.cpp
+++ b/rockin/plugins/drilling_machine/drilling_machine_simulation_thread.cpp
@@ -101,6 +101,8 @@ void DrillingMachineSimulationThread::loop()
 
 DrillingMachineStatus::State DrillingMachineSimulationThread::clips_get_device_state()
 {
+    fawkes::MutexLocker lock(clips_mutex);
+
     if (last_status_msg_.has_state())
     {
         return last_status_msg_.state();
@@ -110,6 +112,7 @@ DrillingMachineStatus::State DrillingMachineSimulationThread::clips_get_device_s
 
 int DrillingMachineSimulationThread::clips_is_device_connected()
 {
+    fawkes::MutexLocker lock(clips_mutex);
     return (last_status_msg_.has_is_device_connected() && last_status_msg_.is_device_connected());
 }
 
@@ -131,6 +134,7 @@ void DrillingMachineSimulationThread::moveDrill(DrillingMachineCommand::Command 
     if (time_diff.total_milliseconds() < 200)
         return;
 
+    fawkes::MutexLocker lock(clips_mutex);
     last_command_msg_.set_command(drill_command);
     last_sent_command_timestamp_ = boost::posix_time::microsec_clock::local_time();
 

--- a/rockin/plugins/drilling_machine/drilling_machine_simulation_thread.h
+++ b/rockin/plugins/drilling_machine/drilling_machine_simulation_thread.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+ *  drilling_machine_simulation_thread.h - Thread to simulate the drilling machine
+ *
+ *  Created: Mon Oct 5 12:20:11 2015
+ *  Copyright  2015 Alexander Moriarty
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef __PLUGINS_DRILLING_MACHINE_SIMULATION_THREAD_H_
+#define __PLUGINS_DRILLING_MACHINE_SIMULATION_THREAD_H_
+
+#include <core/threading/thread.h>
+#include <aspect/logging.h>
+#include <aspect/clips.h>
+#include <aspect/configurable.h>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <plugins/msgs/DeviceDrillingMachine.pb.h>
+
+class DrillingMachineSimulationThread: public fawkes::Thread, public fawkes::LoggingAspect, public fawkes::ConfigurableAspect, public fawkes::CLIPSAspect
+{
+    public:
+        DrillingMachineSimulationThread();
+
+        virtual void init();
+        virtual void loop();
+        virtual void finalize();
+
+    private:
+        void clips_move_drill_up();
+        void clips_move_drill_down();
+        DrillingMachineStatus::State clips_get_device_state();
+        int clips_is_device_connected();
+
+        void moveDrill(DrillingMachineCommand::Command drill_command);
+
+    private:
+        int tick_;
+        static const int ENCODER_MAX_ = 40;
+
+        unsigned int cfg_timer_interval_;
+
+        DrillingMachineStatus last_status_msg_;
+        DrillingMachineCommand last_command_msg_;
+
+        boost::posix_time::ptime prev_device_update_timestamp_;
+        boost::posix_time::ptime last_sent_command_timestamp_;
+};
+
+#endif

--- a/rockin/plugins/drilling_machine/drilling_machine_thread.cpp
+++ b/rockin/plugins/drilling_machine/drilling_machine_thread.cpp
@@ -174,11 +174,9 @@ void DrillingMachineThread::moveDrill(DrillingMachineCommand::Command drill_comm
 
         last_sent_command_timestamp_ = boost::posix_time::microsec_clock::local_time();
 
-        logger->log_info("DrillingMachine", "Send drill command: %d", command_msg.command());
-
     } catch (fawkes::Exception &e)
     {
-        logger->log_warn("DrillingMachine", "Failed to send drilling command: %s", e.what());
+        logger->log_debug("DrillingMachine", "Failed to send drilling command: %s", e.what());
 
         if (query != NULL)
             delete query;

--- a/rockin/plugins/drilling_machine/drilling_machine_thread.cpp
+++ b/rockin/plugins/drilling_machine/drilling_machine_thread.cpp
@@ -53,31 +53,28 @@ void DrillingMachineThread::init()
 
     try
     {
-        if (config->get_bool("/llsfrb/drilling-machine/enable"))
+        if (config->exists("/llsfrb/drilling-machine/host") && config->exists("/llsfrb/drilling-machine/command_port") && config->exists("/llsfrb/drilling-machine/status_port"))
         {
-            if (config->exists("/llsfrb/drilling-machine/host") && config->exists("/llsfrb/drilling-machine/command_port") && config->exists("/llsfrb/drilling-machine/status_port"))
-            {
-                host_ip_address = config->get_string("/llsfrb/drilling-machine/host");
-                host_command_port = "epgm://" + default_network_interface_ + ":" + boost::lexical_cast<std::string>(config->get_uint("/llsfrb/drilling-machine/command_port"));
-                host_status_port = "epgm://" + host_ip_address + ":" + boost::lexical_cast<std::string>(config->get_uint("/llsfrb/drilling-machine/status_port"));
+            host_ip_address = config->get_string("/llsfrb/drilling-machine/host");
+            host_command_port = "epgm://" + default_network_interface_ + ":" + boost::lexical_cast<std::string>(config->get_uint("/llsfrb/drilling-machine/command_port"));
+            host_status_port = "epgm://" + host_ip_address + ":" + boost::lexical_cast<std::string>(config->get_uint("/llsfrb/drilling-machine/status_port"));
 
-                zmq_context_ = new zmq::context_t(1);
+            zmq_context_ = new zmq::context_t(1);
 
-                int msg_limit = 1;
+            int msg_limit = 1;
 
-                // add publisher to send status messages
-                logger->log_info("DrillingMachine", "Connecting to the command port: %s", host_command_port.c_str());
-                zmq_publisher_ = new zmq::socket_t(*zmq_context_, ZMQ_PUB);
-                zmq_publisher_->setsockopt(ZMQ_CONFLATE, &msg_limit, sizeof(msg_limit));
-                zmq_publisher_->bind(host_command_port.c_str());
+            // add publisher to send status messages
+            logger->log_info("DrillingMachine", "Connecting to the command port: %s", host_command_port.c_str());
+            zmq_publisher_ = new zmq::socket_t(*zmq_context_, ZMQ_PUB);
+            zmq_publisher_->setsockopt(ZMQ_CONFLATE, &msg_limit, sizeof(msg_limit));
+            zmq_publisher_->bind(host_command_port.c_str());
 
-                // add subscriber to receive command messages from a client
-                logger->log_info("DrillingMachine", "Connecting to the status port: %s", host_status_port.c_str());
-                zmq_subscriber_ = new zmq::socket_t(*zmq_context_, ZMQ_SUB);
-                zmq_subscriber_->setsockopt(ZMQ_SUBSCRIBE, "", 0);
-                zmq_subscriber_->setsockopt(ZMQ_CONFLATE, &msg_limit, sizeof(msg_limit));
-                zmq_subscriber_->connect(host_status_port.c_str());
-            }
+            // add subscriber to receive command messages from a client
+            logger->log_info("DrillingMachine", "Connecting to the status port: %s", host_status_port.c_str());
+            zmq_subscriber_ = new zmq::socket_t(*zmq_context_, ZMQ_SUB);
+            zmq_subscriber_->setsockopt(ZMQ_SUBSCRIBE, "", 0);
+            zmq_subscriber_->setsockopt(ZMQ_CONFLATE, &msg_limit, sizeof(msg_limit));
+            zmq_subscriber_->connect(host_status_port.c_str());
         }
     } catch (fawkes::Exception &e)
     {

--- a/rockin/plugins/drilling_machine/drilling_machine_thread.cpp
+++ b/rockin/plugins/drilling_machine/drilling_machine_thread.cpp
@@ -120,6 +120,8 @@ void DrillingMachineThread::loop()
 
 DrillingMachineStatus::State DrillingMachineThread::clips_get_device_state()
 {
+    fawkes::MutexLocker lock(clips_mutex);
+
     if (last_status_msg_.has_state())
     {
         return last_status_msg_.state();
@@ -130,6 +132,7 @@ DrillingMachineStatus::State DrillingMachineThread::clips_get_device_state()
 
 int DrillingMachineThread::clips_is_device_connected()
 {
+    fawkes::MutexLocker lock(clips_mutex);
     return (last_status_msg_.has_is_device_connected() && last_status_msg_.is_device_connected());
 }
 
@@ -152,6 +155,7 @@ void DrillingMachineThread::moveDrill(DrillingMachineCommand::Command drill_comm
     if (!zmq_publisher_)
         return;
 
+    fawkes::MutexLocker lock(clips_mutex);
     // prevent sending to many messages to the device
     time_diff = boost::posix_time::microsec_clock::local_time() - last_sent_command_timestamp_;
     if (time_diff.total_milliseconds() < 200)


### PR DESCRIPTION
Adds drilling_machine_simulation_thread and drilling_machine_mockup_thread

In simulation mode, the drilling machine the operation is simulated.
In mockup mode, clips functions are exposed but nothing is simulated.

This pull request closes #10. Feedback and re-factoring has been incorporated.
